### PR TITLE
graphengine submodule bug

### DIFF
--- a/build-vapoursynth.sh
+++ b/build-vapoursynth.sh
@@ -105,6 +105,7 @@ if [ ! -f "$my_pkg_config_path/zimg.pc" ]; then
   retry_git_clone https://github.com/sekrit-twc/zimg
   cd zimg
   git checkout $(git tag | sort -V | tail -1)
+  git submodule update --init --recursive
   autoreconf -if
   ./configure --prefix="$VSPREFIX" --disable-static
   make -j$JOBS


### PR DESCRIPTION
fix build error

make[1]: Entering directory '/root/build-ffmpeg/zimg'
make[1]: *** No rule to make target 'graphengine/graphengine/cpuinfo.cpp', needed by 'graphengine/graphengine/libzimg_internal_la-cpuinfo.lo'. Stop.
make[1]: Leaving directory '/root/build-ffmpeg/zimg'
make: *** [Makefile:4205: all-recursive] Error 1