### PR TITLE
new fixes for building the addons again

### DIFF
--- a/build-plugins.sh
+++ b/build-plugins.sh
@@ -45,7 +45,13 @@ sudo add-apt-repository ppa:ubuntu-toolchain-r/test
     gcc-11 \
     llvm-11-dev \
     libjansson-dev \
-    python3-testresources
+    python3-testresources \
+    libxxhash-dev 
+    
+
+  #  libxxhash-dev Run-time dependency libxxhash for BestSource
+  
+    
   # only on Ubuntu 16.04 ...
   # sudo apt install --no-install-recommends libcompute-dev || true
   #touch $stamp

--- a/build-plugins/header.sh
+++ b/build-plugins/header.sh
@@ -83,7 +83,7 @@ finish ()
 build ()
 {
   if [ -f meson.build ]; then
-    meson build
+    meson setup build
     ninja -C build -j$JOBS
   elif [ -f waf ]; then
     python3 ./waf configure

--- a/build-vapoursynth.sh
+++ b/build-vapoursynth.sh
@@ -142,7 +142,7 @@ fi
 
 # ffmpeg
 if [ ! -f "$my_pkg_config_path/libavcodec.pc" ]; then
-  git clone https://github.com/FFmpeg/FFmpeg --branch release/6.0 
+  git clone https://github.com/FFmpeg/FFmpeg --branch release/6.1 
   cd FFmpeg
   ./configure --prefix="$VSPREFIX" \
     --disable-static \


### PR DESCRIPTION
With these fixes the addons wil build again. No upgrade of Ubuntu 22.04 LTS needed.
But we will need to update FFMPEG from 6.0 to 6.1 because of updated dependencies/libraries.
```
libavcodec: >= 60.31.102
libavformat: >= 60.16.100
libavutil: >= 58.29.100

```
The updates are needed to compile bestsource again.

Note: bestsource plugin behaves a bit strange during compilation and linking!

With the "set -e" option active in the build shell-script "libbestsource.so" won't be created and copied
to the ~/opt/vapoursynth/vsplugins folder.  The build.log won't show an(y) error(s) -> very strange!?!
With the option deleted the file gets compiled and linked correctly. 
This behavior is also mentioned in the README.md in the dependency section of the bestsource sources on Github.

Linking info: 

    linux-vdso.so.1 (0x00007ffec3ff6000)
	libavcodec.so.60 => /home/user/opt/vapoursynth/lib/libavcodec.so.60 (0x00007da2e5800000)
	libavformat.so.60 => /home/user/opt/vapoursynth/lib/libavformat.so.60 (0x00007da2e5400000)
	libavutil.so.58 => /home/user/opt/vapoursynth/lib/libavutil.so.58 (0x00007da2e4200000)
	libxxhash.so.0 => /lib/x86_64-linux-gnu/libxxhash.so.0 (0x00007da2e6c28000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007da2e3e00000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007da2e6b3f000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007da2e6b1b000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007da2e3a00000)
	libswresample.so.4 => /lib/x86_64-linux-gnu/libswresample.so.4 (0x00007da2e6af9000)
	liblzma.so.5 => /lib/x86_64-linux-gnu/liblzma.so.5 (0x00007da2e57d5000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007da2e57b9000)
	libva.so.2 => /lib/x86_64-linux-gnu/libva.so.2 (0x00007da2e5786000)
	libbz2.so.1.0 => /lib/x86_64-linux-gnu/libbz2.so.1.0 (0x00007da2e5773000)
	libva-drm.so.2 => /lib/x86_64-linux-gnu/libva-drm.so.2 (0x00007da2e576e000)
	libva-x11.so.2 => /lib/x86_64-linux-gnu/libva-x11.so.2 (0x00007da2e5766000)
	libvdpau.so.1 => /lib/x86_64-linux-gnu/libvdpau.so.1 (0x00007da2e5760000)
	libX11.so.6 => /lib/x86_64-linux-gnu/libX11.so.6 (0x00007da2e40c0000)
	/lib64/ld-linux-x86-64.so.2 (0x00007da2e6ca4000)
	libsoxr.so.0 => /lib/x86_64-linux-gnu/libsoxr.so.0 (0x00007da2e56f7000)
	libdrm.so.2 => /lib/x86_64-linux-gnu/libdrm.so.2 (0x00007da2e56e1000)
	libXext.so.6 => /lib/x86_64-linux-gnu/libXext.so.6 (0x00007da2e56cc000)
	libXfixes.so.3 => /lib/x86_64-linux-gnu/libXfixes.so.3 (0x00007da2e56c4000)
	libxcb.so.1 => /lib/x86_64-linux-gnu/libxcb.so.1 (0x00007da2e569a000)
	libgomp.so.1 => /lib/x86_64-linux-gnu/libgomp.so.1 (0x00007da2e53ac000)
	libXau.so.6 => /lib/x86_64-linux-gnu/libXau.so.6 (0x00007da2e5692000)
	libXdmcp.so.6 => /lib/x86_64-linux-gnu/libXdmcp.so.6 (0x00007da2e568a000)
	libbsd.so.0 => /lib/x86_64-linux-gnu/libbsd.so.0 (0x00007da2e5394000)
	libmd.so.0 => /lib/x86_64-linux-gnu/libmd.so.0 (0x00007da2e567d000)

The libbestsource.so addon needs some testing if it is working correctly.