### PR TITLE
python virtualenv and updated dependencies

### DIFF
--- a/build-plugins.sh
+++ b/build-plugins.sh
@@ -20,6 +20,7 @@ sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 #if [ ! -e $stamp -x "/usr/bin/apt" ]; then
   sudo apt update
   sudo apt upgrade
+  sudo apt-get install libopencv-dev # install opencv first using apt-get
   sudo apt install --no-install-recommends \
     build-essential \
     cmake \
@@ -43,10 +44,10 @@ sudo add-apt-repository ppa:ubuntu-toolchain-r/test
     libpng-dev \
     g++-11 \
     gcc-11 \
-    llvm-11-dev \
+    llvm-20-dev \
     libjansson-dev \
     python3-testresources \
-    libvulkan1:i386 libvulkan1 vulkan-validationlayers \
+    libvulkan1 vulkan-validationlayers \
     libxxhash-dev \
     libgsl-dev \
     libturbojpeg0-dev
@@ -86,8 +87,12 @@ if [ ! -x "$VSPREFIX/bin/cmake" ]; then
   rm -rf $dir ${dir}.tar.gz
 fi
 
-pip3 install -q -I --upgrade --user setuptools wheel  # must be installed first
-pip3 install -q -I --upgrade --user meson ninja
+sudo apt install python3-virtualenv
+virtualenv .venv
+. .venv/bin/activate
+pip install setuptools wheel # must be installed first
+pip install meson ninja
+
 echo $PWD
 plugins=$(ls -1 ../build-plugins/plugin-*.sh | sed 's|^\.\./build-plugins/plugin-||g; s|\.sh$||g')
 #plugins="bore"
@@ -111,7 +116,8 @@ done
 
 unset vsprefix
 
-pip3 uninstall -y -q setuptools wheel meson ninja
+deactivate
+rm -rf .venv
 
 cd $build_pwd/..
 rm -rf build
@@ -119,5 +125,3 @@ rm -rf build
 s_end=$( date "+%s")
 s=$(($s_end - $s_begin))
 printf "\nFinished after %d min %d sec\n" $(($s / 60)) $(($s % 60))
-
-

--- a/build-vapoursynth.sh
+++ b/build-vapoursynth.sh
@@ -166,7 +166,11 @@ fi
 if [ ! -x "$VSPREFIX/bin/vspipe" ]; then
   old_pythonuserbase="$PYTHONUSERBASE"
   export PYTHONUSERBASE="$PWD/temp"
-  pip3 install -q -I --user cython
+
+  sudo apt install python3-virtualenv
+  virtualenv .venv
+  . .venv/bin/activate
+  pip install cython
 
   retry_git_clone https://github.com/vapoursynth/vapoursynth
   cd vapoursynth
@@ -176,7 +180,8 @@ if [ ! -x "$VSPREFIX/bin/vspipe" ]; then
   make -j$JOBS
   make install-strip
 
-  pip3 uninstall -y -q cython
+  deactivate
+  rm -rf .venv
   export PYTHONUSERBASE="$old_pythonuserbase"
 
   mkdir -p "${vs_site_packages}" "$VSPREFIX/include/vapoursynth" "$VSPREFIX/vsplugins"


### PR DESCRIPTION
With the PR the script now uses a disposable python virtual env instead of installing the pip packages globally.

I have also remove/updated some other packages that are installed via apt/apt-get. Don't know if it's correct, it works on Ubuntu 24.04.

Associated issue: #23 