### PR TITLE
Update NASM 2.16.03/add zig 0.15.2

### DIFF
--- a/build-vapoursynth.sh
+++ b/build-vapoursynth.sh
@@ -38,15 +38,15 @@ sudo apt install --no-install-recommends -y \
   libltdl-dev libva-dev libvdpau-dev libass-dev libtesseract-dev libleptonica-dev \
   zlib1g-dev libbz2-dev libjpeg-dev libpng-dev libtiff-dev liblzma-dev \
   libfontconfig-dev libfreetype6-dev libfftw3-dev libpango1.0-dev libxml2-dev \
-  python3-dev nasm cmake meson ninja-build libopencv-dev \
+  python3-dev cmake meson ninja-build libopencv-dev \
   libboost-dev libboost-system-dev libboost-filesystem-dev \
-  libvulkan1 vulkan-validationlayers cython3
-
+  libvulkan1 vulkan-validationlayers cython3 \
+  llvm-20-dev clang-20 libclang-20-dev lld-20 liblld-20 liblld-20-dev #zig Dependencies
 mkdir -p build && cd build
 
 # NASM
 if [ ! -x "$VSPREFIX/bin/nasm" ]; then
-  ver="2.14.02"
+  ver="2.16.03"
   wget -c https://www.nasm.us/pub/nasm/releasebuilds/$ver/nasm-${ver}.tar.xz
   tar xf nasm-${ver}.tar.xz
   cd "nasm-$ver"
@@ -55,6 +55,23 @@ if [ ! -x "$VSPREFIX/bin/nasm" ]; then
   make install
   cd ..
   rm -rf "nasm-$ver" "nasm-${ver}.tar.xz"
+fi
+
+# ZIG
+if [ ! -x "$VSPREFIX/bin/zig" ]; then
+  ZIG_VERSION="0.15.2"
+  git clone --branch $ZIG_VERSION --depth 1 https://codeberg.org/ziglang/zig.git zig-$ZIG_VERSION
+  cd zig-$ZIG_VERSION
+  mkdir build
+  cd build
+  cmake .. -DCMAKE_INSTALL_PREFIX="$VSPREFIX" \
+    -DCMAKE_PREFIX_PATH="$VSPREFIX" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DZIG_VERSION="$ZIG_VERSION"
+  cmake --build . --parallel "$(nproc)" --target install
+  strip "$VSPREFIX/bin/zig" || true
+  cd ..
+  rm -rf build
 fi
 
 # Zimg
@@ -135,4 +152,3 @@ echo "SystemPluginDir=$VSPREFIX/vsplugins" > "$conf"
 s_end=$(date "+%s")
 s=$((s_end - s_begin))
 printf "\nFinished after %d min %d sec\n" $(($s / 60)) $(($s % 60))
-


### PR DESCRIPTION
NASM 2.16.03
--------------------

NASM 2.14.02 is too old for modern FFmpeg builds.

Many FFmpeg .asm files (especially libavcodec/x86/vp8dsp.asm, x86inc.asm, and x86util.asm) are based on the macro syntax and stack allocation behavior introduced in NASM 2.15 and refined in 2.16+. When using 2.14, macros such as ALLOC_STACK() fail and generate the expected error “)”.

NASM 2.15 is not sufficient for the current FFmpeg version on Ubuntu 24.04 (Noble). The error in libavcodec/x86/hevc/sao.asm with H2656_SAO_EDGE_FILTER shows a multi-parameter macro problem that is only completely fixed in NASM 2.16.

Minimum NASM version for current FFmpeg versions:

FFmpeg git/main (2026): NASM ≥ 2.16.01
FFmpeg n7.0+:          NASM ≥ 2.15.02  
FFmpeg n6.1+:          NASM ≥ 2.14  
Ubuntu 24.04 default:  NASM 2.15.05 (but not for latest ASM)

Zig 0.15.2 added
-------------------------

Zig can now be built from source.
https://codeberg.org/ziglang/zig

The following packages are required:
llvm-20-dev clang-20 libclang-20-dev lld-20 liblld-20 liblld-20-dev #zig Dependencies

!!! With the Zig compiler installed, it is now possible to build the “plugin-zsmooth” yourself from source !!!