### PR TITLE
Update plugin-vslsmashsource.sh / VSPREFIX / meson setup build

### DIFF
--- a/build-plugins/plugin-vslsmashsource.sh
+++ b/build-plugins/plugin-vslsmashsource.sh
@@ -36,4 +36,4 @@ ninja -C build -j $JOBS
 
 cp build/libvslsmashsource.so ../libvslsmashsource.so
 cd ..
-finish libvslsmashsource.s
+finish libvslsmashsource.so


### PR DESCRIPTION
minor corrections

variable $vsprefix -> $VSPREFIX (see config.txt

meson  build -> meson setup build 

(WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.)