### PR TITLE
Update plugin-lghost.sh / VSPREFIX / meson setup build / ninja install

### DIFF
--- a/build-plugins/plugin-lghost.sh
+++ b/build-plugins/plugin-lghost.sh
@@ -8,6 +8,6 @@
 
 ghdl HomeOfVapourSynthEvolution/VapourSynth-LGhost
 
-CFLAGS="$CFLAGS -Wno-deprecated-declarations" meson build --prefix="$vsprefix"
+CFLAGS="$CFLAGS -Wno-deprecated-declarations" meson setup build --prefix="$VSPREFIX"
 ninja -C build -j $JOBS
-ninja -C build install -j $JOBS
+sudo ninja -C build install -j $JOBS


### PR DESCRIPTION
minor corrections

variable $vsprefix -> $VSPREFIX (see config.txt)

meson build -> meson setup build

(WARNING: Running the setup command as meson [options] instead of meson setup [options] is ambiguous and deprecated.)

ninja install -> permission problem?
root cause unknown atm. -> Temporary fix!

ninja -C build install -j $JOBS -> sudo ninja -C build install -j $JOBS

[0/1] Installing files.
Installing liblghost.so to /home/user/opt/vapoursynth/lib/vapoursynth Installation failed due to insufficient permissions. Attempt to use /usr/bin/sudo to gain elevated privileges? [y/n] y [sudo] Passwort für user: 
Installing liblghost.so to /home/user/opt/vapoursynth/lib/vapoursynth


[0/1] Installing files.
Installing liblghost.so to /home/user/opt/vapoursynth/lib/vapoursynth Installation failed due to insufficient permissions. Attempt to use /usr/bin/sudo to gain elevated privileges? [y/n] n Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/mesonbuild/mesonmain.py", line 194, in run
    return options.run_func(options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/mesonbuild/minstall.py", line 873, in run
    installer.do_install(datafilename)
  File "/usr/lib/python3/dist-packages/mesonbuild/minstall.py", line 553, in do_install
    self.install_targets(d, dm, destdir, fullprefix)
  File "/usr/lib/python3/dist-packages/mesonbuild/minstall.py", line 750, in install_targets
    file_copied = self.do_copyfile(fname, outname, makedirs=(dm, outdir))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/mesonbuild/minstall.py", line 430, in do_copyfile
    self.copy2(from_file, to_file)
  File "/usr/lib/python3/dist-packages/mesonbuild/minstall.py", line 327, in copy2
    shutil.copy2(*args, **kwargs)
  File "/usr/lib/python3.12/shutil.py", line 475, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.12/shutil.py", line 262, in copyfile
    with open(dst, 'wb') as fdst:
         ^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/home/user/opt/vapoursynth/lib/vapoursynth/liblghost.so'