### PR TITLE
Update plugin-sangnom.sh / VSPREFIX / meson setup build

### DIFF
--- a/build-plugins/plugin-sangnom.sh
+++ b/build-plugins/plugin-sangnom.sh
@@ -7,7 +7,6 @@
 ##################################################################################
 
 ghdl dubhater/vapoursynth-sangnom
-CFLAGS="$CFLAGS -Wno-deprecated-declarations" meson build --prefix="$vsprefix"
+CFLAGS="$CFLAGS -Wno-deprecated-declarations" meson setup build --prefix="$VSPREFIX"
 ninja -C build -j $JOBS
 ninja -C build install -j $JOBS
-


### PR DESCRIPTION
minor corrections

variable $vsprefix -> $VSPREFIX (see config.txt)

meson build -> meson setup build

(WARNING: Running the setup command as meson [options] instead of meson setup [options] is ambiguous and deprecated.)