### PR TITLE
Update plugin-zsmooth.sh -> Added ability to create zsmooth from the current source code with zig 

### DIFF
--- a/build-plugins/plugin-zsmooth.sh
+++ b/build-plugins/plugin-zsmooth.sh
@@ -1,3 +1,4 @@
+
 ##################################################################################
 #                                                                                #
 #                          Plugin-Zsmooth v0.8                                   #
@@ -6,11 +7,37 @@
 #                                                                                #
 ##################################################################################
 
-wget https://github.com/adworacz/zsmooth/releases/download/0.8/zsmooth-x86_64-linux-gnu.zip
-unzip zsmooth-x86_64-linux-gnu.zip
-mkdir -p $VSPREFIX/vsplugins/
-strip zig-out/lib/libzsmooth.so
-mv zig-out/lib/libzsmooth.so $VSPREFIX/vsplugins/
-chmod u=rw,g=rw,o=r $VSPREFIX/vsplugins/libzsmooth.so
-rm -rf zig-out
-rm -f zsmooth-x86_64-linux-gnu.zip
+# Umgebungsvariable hat Vorrang (Standard: ZIP)
+CHOICE="${ZS_BUILD_METHOD:-1}"
+
+print_message "libzsmooth.so (Methode $CHOICE)..." "libzsmooth.so (method $CHOICE)..."
+
+mkdir -p "$VSPREFIX/vsplugins/"
+
+if [[ "$CHOICE" == "2" ]]; then
+    # Zig Build
+    print_message "🔧 Kompiliere libzsmooth.so mit Zig..." \
+                  "🔧 Compiling libzsmooth.so with Zig..."
+    mkdir -p build && cd build
+    git clone https://github.com/adworacz/zsmooth.git
+    cd zsmooth
+    zig build -j"$(nproc)" -Doptimize=ReleaseFast \
+        -Dtarget=x86_64-linux-gnu.2.17 -Dcpu=x86_64_v3
+    strip zig-out/lib/libzsmooth.so
+    mv zig-out/lib/libzsmooth.so "$VSPREFIX/vsplugins/"
+    cd ../..
+    rm -rf build
+else
+    # ZIP Download
+    print_message "⬇️ Lade libzsmooth.so aus ZIP..." \
+                  "⬇️ Downloading libzsmooth.so from ZIP..."
+    wget -q https://github.com/adworacz/zsmooth/releases/download/0.8/zsmooth-x86_64-linux-gnu.zip
+    unzip -q zsmooth-x86_64-linux-gnu.zip
+    strip zig-out/lib/libzsmooth.so
+    mv zig-out/lib/libzsmooth.so "$VSPREFIX/vsplugins/"
+    rm -rf zig-out zsmooth-x86_64-linux-gnu.zip
+fi
+
+chmod u=rw,g=rw,o=r "$VSPREFIX/vsplugins/libzsmooth.so"
+print_message "✅ libzsmooth.so erfolgreich installiert!" \
+              "✅ libzsmooth.so successfully installed!"


### PR DESCRIPTION
- Added ability to create zsmooth from the current source code with zig 
- Download the Zsmooth library libzsmooth.so from the ZIP archive and use it (**same as before, no change**). 
 -> **Set** as **default**!
- Added variable ZS_BUILD_METHOD to choose :

1. Download libzsmooth as ZIP-archive 
2. Compile libzsmooth from source

How to use:

1.) Execute `./build-plugins.sh`

All plugins will be created as normal.
Zsmooth library is downloaded from the zip archive and installed. (**same as before - no change!**)

2.) Execute `./build-plugins.sh zsmooth`

Only Zsmooth plugin/library is downloaded as ZIP-archive and installed

```
libzsmooth.so (Methode 1)...
⬇️  Lade libzsmooth.so aus ZIP...
✅ libzsmooth.so erfolgreich installiert!

```
3.) Execute `ZS_BUILD_METHOD=2 ./build-plugins.sh zsmooth`

```
libzsmooth.so (Methode 2)...
🔧 Kompiliere libzsmooth.so mit Zig...
Klone nach 'zsmooth' …
remote: Enumerating objects: 2245, done.
remote: Counting objects: 100% (214/214), done.
remote: Compressing objects: 100% (141/141), done. remote: Total 2245 (delta 136), reused 137 (delta 73), pack-reused 2031 (from 2) Empfange Objekte: 100% (2245/2245), 799.87 KiB | 11.59 MiB/s, fertig. Löse Unterschiede auf: 100% (1635/1635), fertig.
[2/5] steps
└─ [5] compile lib zsmooth ReleaseFast x86_64-l
   └─ [2541/2541] Linking
      └─ LLVM Emit Object
✅ libzsmooth.so erfolgreich installiert!
```
Output is from used build.sh generated from
`
cat header.sh plugin-zsmooth.sh >build.sh`
or from the logs in build/logs.

Variable which can be used:

`ZS_BUILD_METHOD=1` -> Download libzsmooth as ZIP-archive 
`ZS_BUILD_METHOD=2` -> Compile libzsmooth from source

Default is "1" -> Download libzsmooth as ZIP-archive !

**Note:** First, I wanted to do this interactively with a menu to choose from. 
But I can't get it to work properly.

**Problem:**
Call several scripts in succession.
stdin/stdout completely redirected to file
read -p / read -r Hang or skip
No terminal available → [[ -t 0 ]] = false
All read variants fail with > log 2>&1 because stdin does not exist.

Any idea how to solve this?

As solution I decided to use the ZS_BUILD_METHOD variable in the meantime.